### PR TITLE
Show queued items in Build Flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.axis.system.jenkins.plugins.downstream</groupId>
       <artifactId>downstream-build-cache</artifactId>
-      <version>1.2</version>
+      <version>1.3-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -5,9 +5,16 @@ import static com.axis.system.jenkins.plugins.downstream.tree.TreeLaminator.layo
 import com.axis.system.jenkins.plugins.downstream.cache.BuildCache;
 import com.axis.system.jenkins.plugins.downstream.tree.Matrix;
 import hudson.Extension;
-import hudson.model.*;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Job;
+import hudson.model.Queue;
+import hudson.model.Run;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
@@ -57,8 +64,17 @@ public class BuildFlowAction implements Action {
     if (target == null) {
       return null;
     }
+    final Queue.Item[] items = Queue.getInstance().getItems();
     return layoutTree(
-        getRootUpstreamBuild(target), b -> BuildCache.getCache().getDownstreamBuilds(b));
+        (Object) getRootUpstreamBuild(target),
+        b -> {
+          List<Object> result = new ArrayList<>();
+          if (b instanceof Run) {
+            result.addAll(BuildCache.getCache().getDownstreamBuilds((Run) b));
+            result.addAll(BuildCache.getDownstreamQueueItems(items, (Run) b));
+          }
+          return result;
+        });
   }
 
   @Override

--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
@@ -1,6 +1,7 @@
 package com.axis.system.jenkins.plugins.downstream.yabv.BuildFlowAction
 
 import com.axis.system.jenkins.plugins.downstream.tree.Matrix
+import hudson.model.Queue
 import hudson.model.Run
 
 import static com.axis.system.jenkins.plugins.downstream.tree.Matrix.Arrow
@@ -29,7 +30,11 @@ table(class: 'downstream-table', cellspacing: 0, cellpadding: 0) {
         }
         td {
           if (cell?.data) {
-            drawBuildInfo(cell.data)
+            if (cell.data instanceof Run) {
+              drawBuildInfo(cell.data)
+            } else if (cell.data instanceof Queue.Item) {
+              drawQueueItemInfo(cell.data)
+            }
           }
         }
       }
@@ -44,6 +49,16 @@ private void drawBuildInfo(Run build) {
     div(class: "build-info ${colorClasses}") {
       a(class: 'build-number model-link inside', href: "${rootURL}/${build.url}") {
         span("${build.parent.name} ${build.displayName}")
+      }
+    }
+  }
+}
+
+private void drawQueueItemInfo(Queue.Item item) {
+  div(class: 'build-wrapper') {
+    div(class: "build-info NOTBUILT ANIME") {
+      a(class: 'build-number model-link inside', href: "${rootURL}/${item.task.url}") {
+        span("${item.task.displayName} (Queued)")
       }
     }
   }


### PR DESCRIPTION
Since we do not want to lock the BuildCache and the Queue
when rendering the Build Flow, there is a very, very small
possibility that a Queue.Item leaves the queue during the
"lamination" of the matrix. In this case the Job will be
visualised both as a Queue.Item and a Downstream build. 

This "approximation" of an ongoing build flow is accepted.

A refresh of the page should fix any visualisation issues
of this kind.
