### PR TITLE
Very small NPE guard

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -42,6 +42,9 @@ public class BuildFlowAction implements Action {
 
   private static Run getUpstreamBuild(@Nonnull Run build) {
     CauseAction causeAction = build.getAction(CauseAction.class);
+    if (causeAction == null) {
+      return null;
+    }
     for (Cause cause : causeAction.getCauses()) {
       if (cause instanceof Cause.UpstreamCause) {
         Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;


### PR DESCRIPTION
In some corner cases, `Run`s might not have a `CauseAction`, resulting in ugly "Oops" errors