### PR TITLE
Use the job's fullDisplayName in the Build Flow diagram

### DIFF
--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
@@ -48,7 +48,7 @@ private void drawBuildInfo(Run build) {
     def colorClasses = color.name().replace('_', ' ') + ' ' + (build == my.target ? 'SELECTED' : '')
     div(class: "build-info ${colorClasses}") {
       a(class: 'build-number model-link inside', href: "${rootURL}/${build.url}") {
-        span("${build.parent.name} ${build.displayName}")
+        span("${build.parent.name} ${build.fullDisplayName}")
       }
     }
   }


### PR DESCRIPTION
For multibranch pipelines this would be better, rather than just displaying the branch name.