### PR TITLE
Fit Build Flow within page width if possible

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/tree/Matrix.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/tree/Matrix.java
@@ -45,6 +45,16 @@ public class Matrix<T> {
     return matrix.get(rowPos).get(colPos);
   }
 
+  /** @return the number of items in the row with largest size */
+  public int getMaxRowWidth() {
+    return matrix.stream().mapToInt(r -> r.size()).max().orElse(0);
+  }
+
+  /** @return if matrix is empty */
+  public boolean isEmpty() {
+    return matrix.isEmpty() || matrix.get(0).isEmpty();
+  }
+
   /**
    * Fetches all cell data and returns as Set
    *
@@ -60,6 +70,11 @@ public class Matrix<T> {
       }
     }
     return resultSet;
+  }
+
+  /** @return the total number of cell in the matrix including null cells */
+  public long getNumberOfCells() {
+    return matrix.stream().mapToInt(r -> r.size()).sum();
   }
 
   /**

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -69,7 +69,7 @@ public class BuildFlowAction implements Action {
 
   public Matrix buildMatrix() {
     if (target == null) {
-      return null;
+      return new Matrix();
     }
     final Queue.Item[] items = Queue.getInstance().getItems();
     return layoutTree(

--- a/src/main/webapp/css/layout.css
+++ b/src/main/webapp/css/layout.css
@@ -1,46 +1,38 @@
-#downstream-table {
-    border-spacing: 0;
+#downstream-grid {
+    display: grid;
+    height: fit-content;
+    height: -moz-fit-content;
+    width: fit-content;
+    width: -moz-fit-content;
 }
 
-#downstream-table > tbody > tr > td {
-    padding: 0;
-    height: 0;
-}
-
-#downstream-table a {
+#downstream-grid a {
+    display: inline-block;
     text-decoration: none;
 }
 
-#downstream-table a:hover {
+#downstream-grid a:hover {
     text-decoration: underline;
 }
 
-#downstream-table span {
-    white-space: nowrap;
+#downstream-grid span {
     font-family: "LatoLatinWeb", "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
     color: black;
     text-decoration: none;
-    line-height: 2em;
     font-size: 1em;
-    padding: 0.0em 0em 0em 0.5em;
 }
 
 .arrow-wrapper {
+    width: 2em;
     height: 100%;
-    width: 2.6em;
-    display: table; /* Solves some minor padding issues i Chrome. */
-}
-
-.build-wrapper {
-    display: inline-block;
-    height: 2.6em;
-    width: 100%;
 }
 
 .build-info {
     margin: 0.3em 0;
-    height: 2.0em;
+    font-size: 1em;
+    line-height: 1em;
     border-radius: 4px;
+    padding: 0.5em;
     position: relative;
 }
 

--- a/src/main/webapp/scripts/ajax-build-flow.js
+++ b/src/main/webapp/scripts/ajax-build-flow.js
@@ -9,7 +9,7 @@ function loadBuildFlow() {
   var xhttp = new XMLHttpRequest();
   xhttp.onreadystatechange = function() {
     if (this.readyState == 4 && this.status == 200) {
-      document.getElementById("downstream-table").outerHTML = this.responseText;
+      document.getElementById("downstream-grid").outerHTML = this.responseText;
     }
   };
   xhttp.open("GET", "yabv/ajaxBuildFlow", true);


### PR DESCRIPTION
If Build Flow graph is too wide, allow breaking lines for a more
narrow width.

Switched from table to CSS grid. This should bring less suprises in
CSS formatting over different browsers.