### PR TITLE
Fix: Ensure Build Flow is dynamically refreshed

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -69,7 +69,7 @@ public class BuildFlowAction implements Action {
     return buildFlowOptions;
   }
 
-  public boolean hasUpstreamOrDownstreamBuilds() {
+  public static boolean hasUpstreamOrDownstreamBuilds(Run target) {
     if (target == null) {
       return false;
     }

--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
@@ -13,7 +13,7 @@ import static com.axis.system.jenkins.plugins.downstream.tree.Matrix.Arrow
 Matrix matrix = my.buildMatrix()
 div(id: 'build-flow-grid',
     style: "grid-template-columns: repeat(${matrix.getMaxRowWidth() * 2}, auto);") {
-  if (matrix.isEmpty() || matrix.numberOfCells == 1) {
+  if (matrix.isEmpty()) {
     return
   }
   Set<Job> jobs = matrix.cellDataAsSet.collect { data ->

--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/jobMain.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/jobMain.groovy
@@ -1,13 +1,14 @@
 package com.axis.system.jenkins.plugins.downstream.yabv.BuildFlowAction
 
+import com.axis.system.jenkins.plugins.downstream.yabv.BuildFlowAction
 import hudson.model.Run
 
 Run lastCompletedBuild = my.target?.parent?.lastCompletedBuild
 Run lastBuild = my.target?.parent?.lastBuild
 
-if (my.hasUpstreamOrDownstreamBuilds(my.target) ||
-    my.hasUpstreamOrDownstreamBuilds(lastCompletedBuild) ||
-    my.hasUpstreamOrDownstreamBuilds(lastBuild)) {
+if (BuildFlowAction.hasUpstreamOrDownstreamBuilds(my.target) ||
+    BuildFlowAction.hasUpstreamOrDownstreamBuilds(lastCompletedBuild) ||
+    BuildFlowAction.hasUpstreamOrDownstreamBuilds(lastBuild)) {
   h2('Build Flow')
   include(my, 'buildFlowJsCss.groovy')
 }

--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/jobMain.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/jobMain.groovy
@@ -1,6 +1,13 @@
 package com.axis.system.jenkins.plugins.downstream.yabv.BuildFlowAction
 
-if (my.hasUpstreamOrDownstreamBuilds()) {
+import hudson.model.Run
+
+Run lastCompletedBuild = my.target?.parent?.lastCompletedBuild
+Run lastBuild = my.target?.parent?.lastBuild
+
+if (my.hasUpstreamOrDownstreamBuilds(my.target) ||
+    my.hasUpstreamOrDownstreamBuilds(lastCompletedBuild) ||
+    my.hasUpstreamOrDownstreamBuilds(lastBuild)) {
   h2('Build Flow')
   include(my, 'buildFlowJsCss.groovy')
 }


### PR DESCRIPTION
+ Allow display of one single build flow cell if more up/downstream
builds are expected to be visualized on future refreshes.

Solves: JENKINS-57933