### PR TITLE
Adjust size of the busy animation for history dots

### DIFF
--- a/src/main/webapp/css/layout.css
+++ b/src/main/webapp/css/layout.css
@@ -53,7 +53,6 @@
     opacity: .14 !important;
 }
 
-
 .duration-info {
     color: rgba(0, 0, 0, 0.8);
     font-size: 0.9em !important;

--- a/src/main/webapp/css/layout.css
+++ b/src/main/webapp/css/layout.css
@@ -48,6 +48,12 @@
     z-index: 1;
 }
 
+.build-flow-build-history-dot:after {
+    background-size: 15px !important;
+    opacity: .14 !important;
+}
+
+
 .duration-info {
     color: rgba(0, 0, 0, 0.8);
     font-size: 0.9em !important;


### PR DESCRIPTION
Since the busy animation for the dots was unscaled, the dots just
looked transparent when both a current and previous build was
ongoing.

Scale the animation to better fit the history dots.

![image](https://user-images.githubusercontent.com/300900/60333289-e9e9c080-9998-11e9-80be-c47e812f08e3.png)
