### PR TITLE
Fix rendering of rebuilt root builds

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -56,7 +56,9 @@ public class BuildFlowAction implements Action {
         Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;
         Job upstreamJob =
             Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
-        if (upstreamJob == null) {
+        // We want to ignore rebuilds, rebuilds have the same parent as
+        // original build, see BuildCache#updateCache().
+        if (upstreamJob == null || build.getParent() == upstreamJob) {
           continue;
         }
         return upstreamJob.getBuildByNumber(upstreamCause.getUpstreamBuild());


### PR DESCRIPTION
This fixes incorrect rendering of build trees where the root job was
a rebuild of another build. The problem was that the tree for the
original build was displayed instead of the tree for the rebuilt build.

I was intending to add a test for this, but after several hours of attempting different solutions I gave up. Put simply, it is really hard to reconstruct a build tree with correct rebuild action/causes. So adding tests is hard, unless we want to introduce a lot of plugin dependencies, and even then it is a pain.