### PR TITLE
Bump downstream build cache version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v.1.9.7
+* Fix: In rare situations concurrent modification exceptions was thrown if multiple child jobs was started at the same time
+
 ## v1.9.6
 * Fix: Wrong build tree was displayed if the root build of the tree was a rebuild of previous build
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
       <name>Gustaf Lundh</name>
       <email>gustaf.lundh@axis.com</email>
     </developer>
+    <developer>
+      <id>jonsten</id>
+      <name>Jon Sten</name>
+      <email>jon.sten@axis.com</email>
+    </developer>
   </developers>
 
   <repositories>
@@ -90,7 +95,7 @@
     <dependency>
       <groupId>com.axis.system.jenkins.plugins.downstream</groupId>
       <artifactId>downstream-build-cache</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The new version fixes concurrency problems in the cache which caused stacktraces under heavy load.