### PR TITLE
[JENKINS-63299] Add switch to hide upstream jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ downstream builds in Jenkins.
   screenshot above, the build currently visited is highlighted using a thick
   dashed border.
 
-* Since the full chain is always shown, the plugin provides easy and fast
-  navigation between all executed builds in the pipeline.
+* Since the full chain is shown, the plugin provides easy and fast navigation
+  between all executed builds in the pipeline.
 
 * Sports nice and modern interface.
 
 * It is compatible with all build types in Jenkins and all known mechanisms of
   triggering downstream builds.
 
-* Switches to enable displaying of build history and build time information.
+* Switches to enable displaying of build history, build time information, and
+  to show/hide upstream builds.
 
 * Provides visualization without adding actions or tagging builds in Jenkins
   with additional meta-data, hence it is totally non-destructive and safe for

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -54,7 +54,7 @@ public class BuildFlowAction implements Action {
       }
       return result;
     };
-  };
+  }
 
   private static Run getRootUpstreamBuild(@Nonnull Run build) {
     Run parentBuild;
@@ -139,7 +139,8 @@ public class BuildFlowAction implements Action {
     if (target == null) {
       return new Matrix();
     }
-    return layoutTree((Object) getRootUpstreamBuild(target), getChildrenFunc());
+    Run root = buildFlowOptions.isShowUpstreamBuilds() ? getRootUpstreamBuild(target) : target;
+    return layoutTree(root, getChildrenFunc());
   }
 
   @Override
@@ -163,6 +164,8 @@ public class BuildFlowAction implements Action {
         Boolean.parseBoolean(req.getParameter("showDurationInfo")));
     buildFlowOptions.setShowBuildHistory(
         Boolean.parseBoolean(req.getParameter("showBuildHistory")));
+    buildFlowOptions.setShowUpstreamBuilds(
+        Boolean.parseBoolean(req.getParameter("showUpstreamBuilds")));
     rsp.setContentType("text/html;charset=UTF-8");
     req.getView(this, "buildFlow.groovy").forward(req, rsp);
   }

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowOptions.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowOptions.java
@@ -3,15 +3,19 @@ package com.axis.system.jenkins.plugins.downstream.yabv;
 public class BuildFlowOptions {
   private boolean showBuildHistory;
   private boolean showDurationInfo;
+  private boolean showUpstreamBuilds;
 
   public BuildFlowOptions() {
     showBuildHistory = false;
     showDurationInfo = false;
+    showUpstreamBuilds = false;
   }
 
-  public BuildFlowOptions(boolean showBuildHistory, boolean showDurationInfo) {
+  public BuildFlowOptions(
+      boolean showBuildHistory, boolean showDurationInfo, boolean showUpstreamBuilds) {
     this.showBuildHistory = showBuildHistory;
     this.showDurationInfo = showDurationInfo;
+    this.showUpstreamBuilds = showUpstreamBuilds;
   }
 
   public boolean isShowBuildHistory() {
@@ -30,11 +34,20 @@ public class BuildFlowOptions {
     this.showDurationInfo = showDurationInfo;
   }
 
+  public boolean isShowUpstreamBuilds() {
+    return showUpstreamBuilds;
+  }
+
+  public void setShowUpstreamBuilds(boolean showUpstreamBuilds) {
+    this.showUpstreamBuilds = showUpstreamBuilds;
+  }
+
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("BuildFlowOptions{");
     sb.append("showBuildHistory=").append(showBuildHistory);
     sb.append(", showDurationInfo=").append(showDurationInfo);
+    sb.append(", showUpstreamBuilds=").append(showUpstreamBuilds);
     sb.append('}');
     return sb.toString();
   }

--- a/src/main/webapp/css/layout.css
+++ b/src/main/webapp/css/layout.css
@@ -33,9 +33,12 @@
     text-decoration: none !important;
 }
 
-.build-flow-switch:hover {
+.build-flow-switch.ACTIVE {
     background-color: #333;
-    text-decoration: none;
+}
+
+.build-flow-switch:hover {
+    background-color: darkorange;
 }
 
 .build-flow-build-history {

--- a/src/main/webapp/scripts/render.js
+++ b/src/main/webapp/scripts/render.js
@@ -9,11 +9,10 @@ function loadBuildFlow() {
       Behaviour.applySubtree(newGrid);
     }
   };
-  var showDurationInfo = getCookie("yabv.showDurationInfo");
-  var showBuildHistory = getCookie("yabv.showBuildHistory");
-  xhttp.open("GET",
-    `yabv/buildFlow?showDurationInfo=${showDurationInfo}&showBuildHistory=${showBuildHistory}`,
-    true);
+  var queryParams = ["showDurationInfo", "showBuildHistory", "showUpstreamBuilds"].map(function(name) {
+    return `${name}=${isOptionActive(name)}`
+  });
+  xhttp.open("GET", `yabv/buildFlow?${queryParams.join("&")}`, true);
   xhttp.send();
 }
 
@@ -25,21 +24,32 @@ function setCookie(name, value) {
 }
 
 function getCookie(name) {
-    var value = document.cookie.match('(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)');
-    return value ? value.pop() : '';
+  var value = document.cookie.match('(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)');
+  return value ? value.pop() : '';
 }
 
-function toggleOption(name) {
-  var show = getCookie("yabv." + name);
-  show = (show === "true" ? show = "false" : show = "true")
-  setCookie("yabv." + name, show);
+function isOptionActive(option) {
+  return getCookie("yabv." + option) === "true";
+}
+function toggleOption(switchA, option) {
+  setCookie("yabv." + option, isOptionActive(option) ? "false" : "true");
+  setSwitchActiveState(switchA, option);
   loadBuildFlow();
+}
+
+function setSwitchActiveState(switchA, option) {
+  if (isOptionActive(option)) {
+    switchA.classList.add('ACTIVE');
+  } else {
+    switchA.classList.remove('ACTIVE');
+  }
 }
 
 function createOptionSwitch(name, option) {
   var switchA = document.createElement("a");
-  switchA.onclick = function() { toggleOption(option); return false; };
+  switchA.onclick = function() { toggleOption(switchA, option); return false; };
   switchA.classList.add("build-flow-switch");
+  setSwitchActiveState(switchA, option);
   switchA.href = "#";
 
   var switchSpan = document.createElement("span");
@@ -51,6 +61,7 @@ function createOptionSwitch(name, option) {
 
 createOptionSwitch("Toggle Time", "showDurationInfo");
 createOptionSwitch("Toggle Build History", "showBuildHistory");
+createOptionSwitch("Toggle Upstream Builds", "showUpstreamBuilds");
 
 if (typeof buildFlowRefreshInterval !== 'undefined' &&
   Number.isInteger(parseInt(buildFlowRefreshInterval)) &&

--- a/src/main/webapp/scripts/render.js
+++ b/src/main/webapp/scripts/render.js
@@ -9,7 +9,7 @@ function loadBuildFlow() {
       Behaviour.applySubtree(newGrid);
     }
   };
-  var queryParams = ["showDurationInfo", "showBuildHistory", "showUpstreamBuilds"].map(function(name) {
+  var queryParams = Object.keys(buildFlowOptions).map(function(name) {
     return `${name}=${isOptionActive(name)}`
   });
   xhttp.open("GET", `yabv/buildFlow?${queryParams.join("&")}`, true);
@@ -28,11 +28,23 @@ function getCookie(name) {
   return value ? value.pop() : '';
 }
 
-function isOptionActive(option) {
-  return getCookie("yabv." + option) === "true";
+function setOptionActive(option, active) {
+  setCookie("yabv." + option, active ? "true" : "false");
 }
+
+function isOptionActive(option) {
+  var value = getCookie("yabv." + option);
+  if (value === "true") {
+    return true;
+  } else if (value === "false") {
+    return false;
+  } else {
+    return buildFlowOptions[option].defaultValue;
+  }
+}
+
 function toggleOption(switchA, option) {
-  setCookie("yabv." + option, isOptionActive(option) ? "false" : "true");
+  setOptionActive(option, !isOptionActive(option));
   setSwitchActiveState(switchA, option);
   loadBuildFlow();
 }
@@ -45,7 +57,7 @@ function setSwitchActiveState(switchA, option) {
   }
 }
 
-function createOptionSwitch(name, option) {
+function createOptionSwitch(option) {
   var switchA = document.createElement("a");
   switchA.onclick = function() { toggleOption(switchA, option); return false; };
   switchA.classList.add("build-flow-switch");
@@ -53,15 +65,30 @@ function createOptionSwitch(name, option) {
   switchA.href = "#";
 
   var switchSpan = document.createElement("span");
-  switchSpan.innerHTML = name;
+  switchSpan.innerHTML = buildFlowOptions[option].title
 
   switchA.appendChild(switchSpan);
   document.getElementById("build-flow-switches").appendChild(switchA);
 }
 
-createOptionSwitch("Toggle Time", "showDurationInfo");
-createOptionSwitch("Toggle Build History", "showBuildHistory");
-createOptionSwitch("Toggle Upstream Builds", "showUpstreamBuilds");
+var buildFlowOptions = {
+  "showDurationInfo": {
+    title: "Toggle Time",
+    defaultValue: false
+  },
+  "showBuildHistory": {
+    title: "Toggle Build History",
+    defaultValue: false
+  },
+  "showUpstreamBuilds": {
+    title: "Toggle Upstream Builds",
+    defaultValue: true
+  }
+};
+
+for (option in buildFlowOptions) {
+  createOptionSwitch(option);
+}
 
 if (typeof buildFlowRefreshInterval !== 'undefined' &&
   Number.isInteger(parseInt(buildFlowRefreshInterval)) &&


### PR DESCRIPTION
[JENKINS-63299](https://issues.jenkins-ci.org/browse/JENKINS-63299) - Add switch to hide upstream jobs
-
Added ability to show/hide upstream jobs.
Improved toggle switch, so that UI shows the current on/off state.
Small js refactoring, to reduce the number of places a new switch id needs to be added to.