### PR TITLE
Update Warning/Information symbol used when cache is still refreshing

### DIFF
--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
@@ -14,7 +14,7 @@ import static com.axis.system.jenkins.plugins.downstream.tree.Matrix.Arrow
 
 div(id: 'build-flow-cache-refreshing-warning') {
   if (BuildCache.cache.isCacheRefreshing()) {
-    span("🛈 Cache is still refreshing, the Build Flow graph may not be complete!")
+    span("⚠ Cache is still refreshing, the Build Flow graph may not be complete!")
   }
 }
 


### PR DESCRIPTION
The old one was not compatible with Debian Buster + Chromium.

This warning symbol should be visible on pretty much browsers.