### PR TITLE
Add button to display Full Build Name

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -218,6 +218,7 @@ public class BuildFlowAction implements Action {
     buildFlowOptions.setShowUpstreamBuilds(
         Boolean.parseBoolean(req.getParameter("showUpstreamBuilds")));
     buildFlowOptions.setFlattenView(Boolean.parseBoolean(req.getParameter("flattenView")));
+    buildFlowOptions.setShowFullNames(Boolean.parseBoolean(req.getParameter("showFullNames")));
     rsp.setContentType("text/html;charset=UTF-8");
     req.getView(this, "buildFlow.groovy").forward(req, rsp);
   }

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowOptions.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowOptions.java
@@ -5,23 +5,27 @@ public class BuildFlowOptions {
   private boolean showDurationInfo;
   private boolean showUpstreamBuilds;
   private boolean flattenView;
+  private boolean showFullNames;
 
   public BuildFlowOptions() {
     showBuildHistory = false;
     showDurationInfo = false;
     showUpstreamBuilds = false;
     flattenView = false;
+    showFullNames = false;
   }
 
   public BuildFlowOptions(
       boolean showBuildHistory,
       boolean showDurationInfo,
       boolean showUpstreamBuilds,
-      boolean flattenView) {
+      boolean flattenView,
+      boolean showFullNames) {
     this.showBuildHistory = showBuildHistory;
     this.showDurationInfo = showDurationInfo;
     this.showUpstreamBuilds = showUpstreamBuilds;
     this.flattenView = flattenView;
+    this.showFullNames = showFullNames;
   }
 
   public boolean isShowBuildHistory() {
@@ -56,6 +60,14 @@ public class BuildFlowOptions {
     this.flattenView = flattenView;
   }
 
+  public boolean isShowFullNames() {
+    return showFullNames;
+  }
+
+  public void setShowFullNames(boolean showFullNames) {
+    this.showFullNames = showFullNames;
+  }
+
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("BuildFlowOptions{");
@@ -63,6 +75,7 @@ public class BuildFlowOptions {
     sb.append(", showDurationInfo=").append(showDurationInfo);
     sb.append(", showUpstreamBuilds=").append(showUpstreamBuilds);
     sb.append(", flattenView=").append(flattenView);
+    sb.append(", showFullNames=").append(showFullNames);
     sb.append('}');
     return sb.toString();
   }

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/NameNormalizer.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/NameNormalizer.java
@@ -12,10 +12,16 @@ public class NameNormalizer<T> {
   Set<String> blacklist;
   NameFunction<T> nameFunc;
   ParentFunction<T> parentFunc;
+  boolean showFullNames;
 
   public NameNormalizer(Set<T> items, NameFunction<T> nameFunc, ParentFunction<T> parentFunc) {
+    this (items, nameFunc, parentFunc, false);
+  }
+
+  public NameNormalizer(Set<T> items, NameFunction<T> nameFunc, ParentFunction<T> parentFunc, boolean showFullNames) {
     this.nameFunc = nameFunc;
     this.parentFunc = parentFunc;
+    this.showFullNames = showFullNames;
     blacklist = generateBlacklist(items, nameFunc, parentFunc);
   }
 
@@ -58,12 +64,15 @@ public class NameNormalizer<T> {
     List<String> nameSegments = new ArrayList<>();
     for (; item != null; item = parentFunc.parent(item)) {
       nameSegments.add(0, parentFunc.parent(item) != null ? nameFunc.name(item) : ROOT_NAME);
-      String formattedName = String.join(NAME_SEPARATOR, nameSegments);
-      if (!blacklist.contains(formattedName)) {
-        return formattedName;
+      if(!this.showFullNames) {
+        String formattedName = String.join(NAME_SEPARATOR, nameSegments);
+        if (!blacklist.contains(formattedName)) {
+          return formattedName;
+        }
       }
     }
     // Should never happen unless an item we iterated over provided an empty String for name.
+    // Or showFullNames is set to tru
     // In this case we just return what we have.
     return String.join(NAME_SEPARATOR, nameSegments);
   }

--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
@@ -37,7 +37,7 @@ if (options.flattenView) {
       return
     }
 
-    NameNormalizer nameNormalizer = getNameNormalizer(allJobs.toSet())
+    NameNormalizer nameNormalizer = getNameNormalizer(allJobs.toSet(), options.showFullNames)
 
     allJobs.each { job ->
       drawJobInfo(job, nameNormalizer)
@@ -66,7 +66,7 @@ if (options.flattenView) {
       getJob(data)
     }.toSet()
 
-    NameNormalizer nameNormalizer = getNameNormalizer(jobs)
+    NameNormalizer nameNormalizer = getNameNormalizer(jobs, options.showFullNames)
 
     matrix.get().each { row ->
       div(style: 'grid-column-start: 1') { }
@@ -87,12 +87,13 @@ private static Job getJob(Object data) {
   return null
 }
 
-private static NameNormalizer getNameNormalizer(Set<Job> jobs) {
+private static NameNormalizer getNameNormalizer(Set<Job> jobs, boolean showFullNames) {
   return new NameNormalizer(jobs, {
     it.displayName
   }, {
     it instanceof Item ? it.parent : null
-  })
+  },
+    showFullNames)
 }
 
 private void drawCellData(Object data, NameNormalizer nameNormalizer, BuildFlowOptions options) {

--- a/src/main/webapp/scripts/render.js
+++ b/src/main/webapp/scripts/render.js
@@ -87,6 +87,10 @@ var buildFlowOptions = {
   "flattenView": {
     title: "Flatten Graph",
     defaultValue: false
+  },
+  "showFullNames": {
+      title: "Toggle Full Names",
+      defaultValue: false
   }
 };
 

--- a/src/test/groovy/com/axis/system/jenkins/plugins/downstream/yabv/NameNormalizerTest.groovy
+++ b/src/test/groovy/com/axis/system/jenkins/plugins/downstream/yabv/NameNormalizerTest.groovy
@@ -58,4 +58,63 @@ class NameNormalizerTest {
     assert nameNormalizer.getNormalizedName(itemB) == 'd/a'
     assert nameNormalizer.getNormalizedName(itemC) == 'b'
   }
+
+  @Test
+  void singleItemNoCollisionsMin2() {
+    def itemA = ['a', 'b', 'root']
+    def nameNormalizer = new NameNormalizer([itemA].toSet(), NAME_FUNC, PARENT_FUNC, true)
+    assert nameNormalizer.getNormalizedName(itemA) == '/b/a'
+  }
+
+  @Test
+  void multipleItemsNoCollisionsMin2() {
+    def itemA = ['a', 'b', 'root']
+    def itemB = ['b', 'b', 'root']
+
+    def nameNormalizer = new NameNormalizer([itemA, itemB].toSet(), NAME_FUNC, PARENT_FUNC, true)
+    assert nameNormalizer.getNormalizedName(itemA) == '/b/a'
+    assert nameNormalizer.getNormalizedName(itemB) == '/b/b'
+  }
+
+  @Test
+  void multipleItemsCollisionsMin2() {
+    def itemA = ['a', 'b', 'root']
+    def itemB = ['a', 'd', 'root']
+
+    def nameNormalizer = new NameNormalizer([itemA, itemB].toSet(), NAME_FUNC, PARENT_FUNC, true)
+    assert nameNormalizer.getNormalizedName(itemA) == '/b/a'
+    assert nameNormalizer.getNormalizedName(itemB) == '/d/a'
+  }
+
+  @Test
+  void longItemsNoCollisionsMin2() {
+    def itemA = ['a', 'b', 'c', 'root']
+    def itemB = ['d', 'e', 'f', 'root']
+
+    def nameNormalizer = new NameNormalizer([itemA, itemB].toSet(), NAME_FUNC, PARENT_FUNC, true)
+    assert nameNormalizer.getNormalizedName(itemA) == '/c/b/a'
+    assert nameNormalizer.getNormalizedName(itemB) == '/f/e/d'
+  }
+
+  @Test
+  void rootCollisionsMin2() {
+    def itemA = ['a', 'b', 'root']
+    def itemB = ['a', 'root']
+
+    def nameNormalizer = new NameNormalizer([itemA, itemB].toSet(), NAME_FUNC, PARENT_FUNC, true)
+    assert nameNormalizer.getNormalizedName(itemB) == '/a'
+    assert nameNormalizer.getNormalizedName(itemA) == '/b/a'
+  }
+
+  @Test
+  void innocentBystanderMin2() {
+    def itemA = ['a', 'b', 'root']
+    def itemB = ['a', 'd', 'root']
+    def itemC = ['b', 'd', 'root']
+
+    def nameNormalizer = new NameNormalizer([itemA, itemB].toSet(), NAME_FUNC, PARENT_FUNC, true)
+    assert nameNormalizer.getNormalizedName(itemA) == '/b/a'
+    assert nameNormalizer.getNormalizedName(itemB) == '/d/a'
+    assert nameNormalizer.getNormalizedName(itemC) == '/d/b'
+  }
 }


### PR DESCRIPTION
When using multibranch pipelines, displayed job name can be reduced to just branch name (e.g. `master` / `main`) which makes hard to understand which build was triggered.

 The issue was described in https://issues.jenkins.io/browse/JENKINS-66724

I added a new button which can switch between showing normalized build name and full build name.

I also thought about enforcing at least 2 elements on path, but that solution is less elegant.
Implementation of enforcing at least 2 elements can be found here: https://github.com/jangalda-nsc/yet-another-build-visualizer-plugin/tree/minimum2elements

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
