### PR TITLE
Add button to display Build Description

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction.java
@@ -211,6 +211,8 @@ public class BuildFlowAction implements Action {
 
   public void doBuildFlow(StaplerRequest req, StaplerResponse rsp)
       throws IOException, ServletException {
+    buildFlowOptions.setShowDescription(
+        Boolean.parseBoolean(req.getParameter("showDescription")));
     buildFlowOptions.setShowDurationInfo(
         Boolean.parseBoolean(req.getParameter("showDurationInfo")));
     buildFlowOptions.setShowBuildHistory(

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowOptions.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowOptions.java
@@ -6,6 +6,7 @@ public class BuildFlowOptions {
   private boolean showUpstreamBuilds;
   private boolean flattenView;
   private boolean showFullNames;
+  private boolean showDescription;
 
   public BuildFlowOptions() {
     showBuildHistory = false;
@@ -13,6 +14,7 @@ public class BuildFlowOptions {
     showUpstreamBuilds = false;
     flattenView = false;
     showFullNames = false;
+    showDescription = false;
   }
 
   public BuildFlowOptions(
@@ -20,12 +22,14 @@ public class BuildFlowOptions {
       boolean showDurationInfo,
       boolean showUpstreamBuilds,
       boolean flattenView,
-      boolean showFullNames) {
+      boolean showFullNames,
+      boolean showDescription) {
     this.showBuildHistory = showBuildHistory;
     this.showDurationInfo = showDurationInfo;
     this.showUpstreamBuilds = showUpstreamBuilds;
     this.flattenView = flattenView;
     this.showFullNames = showFullNames;
+    this.showDescription = showDescription;
   }
 
   public boolean isShowBuildHistory() {
@@ -68,6 +72,14 @@ public class BuildFlowOptions {
     this.showFullNames = showFullNames;
   }
 
+  public boolean isShowDescription() {
+    return showDescription;
+  }
+
+  public void setShowDescription(boolean showDescription) {
+    this.showDescription = showDescription;
+  }
+
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("BuildFlowOptions{");
@@ -76,6 +88,7 @@ public class BuildFlowOptions {
     sb.append(", showUpstreamBuilds=").append(showUpstreamBuilds);
     sb.append(", flattenView=").append(flattenView);
     sb.append(", showFullNames=").append(showFullNames);
+    sb.append(", showDescription=").append(showDescription);
     sb.append('}');
     return sb.toString();
   }

--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/yabv/BuildFlowAction/buildFlow.groovy
@@ -123,6 +123,9 @@ private void drawBuildInfo(Run build, NameNormalizer nameNormalizer, BuildFlowOp
         span("${nameNormalizer.getNormalizedName(build.parent)} ${build.displayName}")
       }
     }
+    if (options.showDescription && build.description) {
+      span(class: 'description-info', build.description)
+    }
     if (options.showDurationInfo) {
       span(class: 'duration-info', build.durationString)
     }

--- a/src/main/webapp/css/layout.css
+++ b/src/main/webapp/css/layout.css
@@ -61,6 +61,16 @@
     opacity: .14 !important;
 }
 
+.description-info {
+    color: rgba(0, 0, 0, 0.8);
+    font-size: 0.9em !important;
+    font-style: italic;
+    max-width: 32ch;
+    word-wrap: break-word;
+    line-height: 0.9em !important;
+    margin: 1px 0 5px 0;
+}
+
 .duration-info {
     color: rgba(0, 0, 0, 0.8);
     font-size: 0.9em !important;

--- a/src/main/webapp/scripts/render.js
+++ b/src/main/webapp/scripts/render.js
@@ -91,6 +91,10 @@ var buildFlowOptions = {
   "showFullNames": {
       title: "Toggle Full Names",
       defaultValue: false
+  },
+  "showDescription": {
+    title: "Toggle Description",
+    defaultValue: false
   }
 };
 


### PR DESCRIPTION
Our builds share the same name, making it difficult to distinguish between them without opening each one to view its description.

This change introduces a new toggle button (defaulted to false), labelled "Toggle Description," which allows users to display the build description. The description is inserted between the main title and the build duration. The content is word-wrapped (using CSS) to 32 characters (fixed value) to prevent the graph from expanding too much in the case of long descriptions. Additionally, I added a small gap (5px) between the description and a following element.

![image](https://github.com/user-attachments/assets/ded0e67b-e01b-4044-9721-5f925c5e153a)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
